### PR TITLE
Longer Startup Delay

### DIFF
--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -32,7 +32,7 @@ enum pmw3610_init_step {
 // - Since MCU is not involved in the sensor init process, i is allowed to do other tasks.
 //   Thus, k_sleep or delayed schedule can be used.
 static const int32_t async_init_delay[ASYNC_INIT_STEP_COUNT] = {
-    [ASYNC_INIT_STEP_POWER_UP] = 10,   // >10ms needed
+    [ASYNC_INIT_STEP_POWER_UP] = 50,   // >10ms needed
     [ASYNC_INIT_STEP_CLEAR_OB1] = 200, // 150 us required, test shows too short,
                                        // also power-up reset is added in this step, thus using 50 ms
     [ASYNC_INIT_STEP_CHECK_OB1] = 50,  // 10 ms required in spec,

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -32,7 +32,7 @@ enum pmw3610_init_step {
 // - Since MCU is not involved in the sensor init process, i is allowed to do other tasks.
 //   Thus, k_sleep or delayed schedule can be used.
 static const int32_t async_init_delay[ASYNC_INIT_STEP_COUNT] = {
-    [ASYNC_INIT_STEP_POWER_UP] = 500,   // >10ms needed
+    [ASYNC_INIT_STEP_POWER_UP] = 1000,   // >10ms needed
     [ASYNC_INIT_STEP_CLEAR_OB1] = 200, // 150 us required, test shows too short,
                                        // also power-up reset is added in this step, thus using 50 ms
     [ASYNC_INIT_STEP_CHECK_OB1] = 50,  // 10 ms required in spec,

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -32,7 +32,7 @@ enum pmw3610_init_step {
 // - Since MCU is not involved in the sensor init process, i is allowed to do other tasks.
 //   Thus, k_sleep or delayed schedule can be used.
 static const int32_t async_init_delay[ASYNC_INIT_STEP_COUNT] = {
-    [ASYNC_INIT_STEP_POWER_UP] = 50,   // >10ms needed
+    [ASYNC_INIT_STEP_POWER_UP] = 1000,   // >10ms needed
     [ASYNC_INIT_STEP_CLEAR_OB1] = 200, // 150 us required, test shows too short,
                                        // also power-up reset is added in this step, thus using 50 ms
     [ASYNC_INIT_STEP_CHECK_OB1] = 50,  // 10 ms required in spec,

--- a/src/pmw3610.c
+++ b/src/pmw3610.c
@@ -32,7 +32,7 @@ enum pmw3610_init_step {
 // - Since MCU is not involved in the sensor init process, i is allowed to do other tasks.
 //   Thus, k_sleep or delayed schedule can be used.
 static const int32_t async_init_delay[ASYNC_INIT_STEP_COUNT] = {
-    [ASYNC_INIT_STEP_POWER_UP] = 1000,   // >10ms needed
+    [ASYNC_INIT_STEP_POWER_UP] = 500,   // >10ms needed
     [ASYNC_INIT_STEP_CLEAR_OB1] = 200, // 150 us required, test shows too short,
                                        // also power-up reset is added in this step, thus using 50 ms
     [ASYNC_INIT_STEP_CHECK_OB1] = 50,  // 10 ms required in spec,


### PR DESCRIPTION
Not sure if this is the most effective way to do this, but by significantly increasing the startup delay, I was able to fix the issue on my hardware.

The issue ([originally opened on ZMK](https://github.com/zmkfirmware/zmk/issues/2761))
When either half of the keyboard is initially powered on (via hardware switch or plugging in to USB while power switch is off), that half's PMW3610 won't work until the board is reset (press reset button one time).