### PR TITLE
fix: driver can't be compiled if battery detection is disabled

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -7,7 +7,8 @@
 
 menuconfig PMW3610
     bool "PMW3610 mouse optical sensor"
-  select SPI
+    select SPI
+    select SENSOR
     help
       Enable PMW3610 mouse optical sensor.
 


### PR DESCRIPTION
`CONFIG_SENSOR_INIT_PRIORITY` is used in `src/pmw3610.c:606` which requires the `SENSOR` to be selected.
It is fine in most cases because battery detection normally enabled.
However, it won't work when using ZMK on rp2040 which doesn't need the battery.
