### PR TITLE
Fix/cursor jump and build warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-zephyr_library()
-
-zephyr_library_sources_ifdef(CONFIG_PMW3610 src/pmw3610.c)
-zephyr_include_directories(${APPLICATION_SOURCE_DIR}/include)
+if(CONFIG_PMW3610)
+  zephyr_library()
+  zephyr_library_sources(src/pmw3610.c)
+  zephyr_include_directories(${APPLICATION_SOURCE_DIR}/include)
+endif()

--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -1,0 +1,1 @@
+pixart	PixArt Imaging, Inc.


### PR DESCRIPTION
Fix:
During the wake-up transition, we now:
- Temporarily disable interrupts,
- Read and discard a few stale motion bursts,
- Clear motion registers,
- Re-enable interrupts.