### PR TITLE
Adding PixArt to vendor-prefixes.txt

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -1,0 +1,1 @@
+pixart	PixArt Imaging Inc.


### PR DESCRIPTION
Fixes warning `compatible 'pixart,pmw3610' has unknown vendor prefix 'pixart'`
I requested a vendor update for https://github.com/zmkfirmware/zephyr/pull/48 because upstream https://github.com/zephyrproject-rtos/zephyr has pixart added already.
But I doubt they will update vendors before the next major zephyr version